### PR TITLE
Added a replacement value ("new" by default) for the empty "counters" on the sidebar

### DIFF
--- a/extensions/chrome/facebookdemetricator.chromeextension/facebookdemetricator.user.js
+++ b/extensions/chrome/facebookdemetricator.chromeextension/facebookdemetricator.user.js
@@ -64,6 +64,7 @@ var timelineView = false;
 
 
 // constants
+var DEMETRICATED_SIDEBAR_TEXT = "new"; // used as a replacement text for the values hidden in the sidebar
 var FADE_SPEED = 175;               // used in jQuery fadeIn()/fadeOut()
 var ELEMENT_POLL_SPEED = 750;       // waitForKeyElements polling interval 
 var RIBBON_TEXT_COLOR = "rgb(59,89,152)"; // TODO change this to opacity
@@ -204,6 +205,8 @@ function toggleDemetricator() {
         // event and timeline activity counts (possibly elsewhere)
         j('.counter').fadeOut(FADE_SPEED);
 
+        j('.demetricatedSideBarValue').hide();
+
         if(DBUG) console.timeEnd('demetricatorON timer');
 
 
@@ -289,6 +292,7 @@ function toggleDemetricator() {
             if(cnt) j(this).fadeIn(FADE_SPEED);
         });
 
+        j('.demetricatedSideBarValue').show();
 
         if(DBUG) console.timeEnd('demetricatorOFF timer');
 
@@ -1933,8 +1937,9 @@ function demetricateCounters() {
         // testing this out...hides values on left-hand bar but leaves outlines as
         // newness indicator
         j('.countValue').not('.facebookcount').
-            addClass('facebookcount facebookmetric_opacity').
-            css('opacity','0').
+            addClass('facebookcount facebookmetric_hideshow').
+            hide().
+            before('<span class="demetricatedSideBarValue fss facebookcount">'+DEMETRICATED_SIDEBAR_TEXT+'</span>').
             parent().addClass('facebookcount');
 
         j('.maxCountIndicator').not('.facebookcount').

--- a/extensions/safari/facebookdemetricator.safariextension/facebookdemetricator.user.js
+++ b/extensions/safari/facebookdemetricator.safariextension/facebookdemetricator.user.js
@@ -64,6 +64,7 @@ var timelineView = false;
 
 
 // constants
+var DEMETRICATED_SIDEBAR_TEXT = "new"; // used as a replacement text for the values hidden in the sidebar
 var FADE_SPEED = 175;               // used in jQuery fadeIn()/fadeOut()
 var ELEMENT_POLL_SPEED = 750;       // waitForKeyElements polling interval 
 var RIBBON_TEXT_COLOR = "rgb(59,89,152)"; // TODO change this to opacity
@@ -204,6 +205,8 @@ function toggleDemetricator() {
         // event and timeline activity counts (possibly elsewhere)
         j('.counter').fadeOut(FADE_SPEED);
 
+        j('.demetricatedSideBarValue').hide();
+
         if(DBUG) console.timeEnd('demetricatorON timer');
 
 
@@ -289,6 +292,7 @@ function toggleDemetricator() {
             if(cnt) j(this).fadeIn(FADE_SPEED);
         });
 
+        j('.demetricatedSideBarValue').show();
 
         if(DBUG) console.timeEnd('demetricatorOFF timer');
 
@@ -1933,8 +1937,9 @@ function demetricateCounters() {
         // testing this out...hides values on left-hand bar but leaves outlines as
         // newness indicator
         j('.countValue').not('.facebookcount').
-            addClass('facebookcount facebookmetric_opacity').
-            css('opacity','0').
+            addClass('facebookcount facebookmetric_hideshow').
+            hide().
+            before('<span class="demetricatedSideBarValue fss facebookcount">'+DEMETRICATED_SIDEBAR_TEXT+'</span>').
             parent().addClass('facebookcount');
 
         j('.maxCountIndicator').not('.facebookcount').

--- a/facebookdemetricator.user.js
+++ b/facebookdemetricator.user.js
@@ -64,6 +64,7 @@ var timelineView = false;
 
 
 // constants
+var DEMETRICATED_SIDEBAR_TEXT = "new"; // used as a replacement text for the values hidden in the sidebar
 var FADE_SPEED = 175;               // used in jQuery fadeIn()/fadeOut()
 var ELEMENT_POLL_SPEED = 750;       // waitForKeyElements polling interval 
 var RIBBON_TEXT_COLOR = "rgb(59,89,152)"; // TODO change this to opacity
@@ -204,6 +205,8 @@ function toggleDemetricator() {
         // event and timeline activity counts (possibly elsewhere)
         j('.counter').fadeOut(FADE_SPEED);
 
+        j('.demetricatedSideBarValue').hide();
+
         if(DBUG) console.timeEnd('demetricatorON timer');
 
 
@@ -289,6 +292,7 @@ function toggleDemetricator() {
             if(cnt) j(this).fadeIn(FADE_SPEED);
         });
 
+        j('.demetricatedSideBarValue').show();
 
         if(DBUG) console.timeEnd('demetricatorOFF timer');
 
@@ -2091,8 +2095,9 @@ function demetricateCounters() {
         // testing this out...hides values on left-hand bar but leaves outlines as
         // newness indicator
         j('.countValue').not('.facebookcount').
-            addClass('facebookcount facebookmetric_opacity').
-            css('opacity','0').
+            addClass('facebookcount facebookmetric_hideshow').
+            hide().
+            before('<span class="demetricatedSideBarValue fss facebookcount">'+DEMETRICATED_SIDEBAR_TEXT+'</span>').
             parent().addClass('facebookcount');
 
         j('.maxCountIndicator').not('.facebookcount').


### PR DESCRIPTION
I added a new replacement value ("new by default") to the counters' "holder" that would show when the demetricator script is turned on.